### PR TITLE
Pit update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/target/
+/.settings/
+/.classpath
+/.project

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
       <plugin>
         <groupId>org.pitest</groupId>
         <artifactId>pitest-maven</artifactId>
-        <version>0.25-SNAPSHOT</version>
+        <version>1.1.10</version>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -12,20 +12,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
   
-  <pluginRepositories>
-    <pluginRepository>
-      <id>apache.org</id>
-      <name>Maven Plugin Snapshots</name>
-      <url>http://people.apache.org/repo/m2-snapshot-repository</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </pluginRepository>
-  </pluginRepositories>
-  
   <dependencies>
     <dependency>
       <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.10</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
This PR updates pitest maven to the latest version 1.1.10.
It also removes the reference to the old snapshot repository and also contributes a .gitignore
